### PR TITLE
fix: calculate server ip address

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -272,6 +272,10 @@ func expandSSHKeys(sshKeys []interface{}) []cloudsigma.Keypair {
 }
 
 func findIPv4Address(server *cloudsigma.Server, addrType string) string {
+	if server.Runtime == nil {
+		return ""
+	}
+
 	for _, nic := range server.Runtime.RuntimeNICs {
 		if nic.InterfaceType == addrType {
 			return nic.IPv4.UUID

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudsigma/terraform-provider-cloudsigma
 
 require (
 	github.com/cloudsigma/cloudsigma-sdk-go v0.6.1-0.20201105171248-d68ba0a3b8a7
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-plugin-go v0.1.0 h1:kyXZ0nkHxiRev/q18N40IbRRk4AV0zE/MDJkDM3u8dY=
 github.com/hashicorp/terraform-plugin-go v0.1.0/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0 h1:2m4uKA97R8ijHGLwhHdpSJyI8Op1FpS/ozpoF21jK7s=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0/go.mod h1:+12dJQebYjuU/yiq94iZUPuC66abfRBrXdpVJia3ojk=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0 h1:Egv+R1tOOjPNz643KBTx3tLT6RdFGGYJcZlyLvrPcEU=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0/go.mod h1:+12dJQebYjuU/yiq94iZUPuC66abfRBrXdpVJia3ojk=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=


### PR DESCRIPTION
This PR fixes issue #3.

If a CloudSigma server is not in running state, there is no runtime available. In this case we should return empty string, since no IP address is assigned.