### PR TITLE
chore: add support for openbsd systems

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - freebsd
       - darwin
       - linux
+      - openbsd
       - windows
     mod_timestamp: '{{ .CommitTimestamp }}'
 changelog:


### PR DESCRIPTION
This PR adds openbsd binary in release workflow (goreleaser).