### PR TITLE
fix: revert validate function with diagnostics for ssh_keys

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -85,8 +85,8 @@ func resourceCloudSigmaServer() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:             schema.TypeString,
-					ValidateDiagFunc: validation.ToDiagFunc(validation.NoZeroValues),
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
 				},
 			},
 


### PR DESCRIPTION
This PR uses "old" validation function instead of "new" (with diagnostics support) for `ssh_keys` attributes in `cloudsigma_server` resource.

At the moment SDKv2 doesn't handle parsing attributes names correctly (https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.4.3/helper/validation/meta.go#L69).