### PR TITLE
chore: update CloudSigma SDK library to version v0.9.0

### DIFF
--- a/cloudsigma/config.go
+++ b/cloudsigma/config.go
@@ -21,7 +21,7 @@ type Config struct {
 
 // Client returns a new client for accessing CloudSigma.
 func (c *Config) Client() *cloudsigma.Client {
-	client := cloudsigma.NewBasicAuthClient(c.Username, c.Password)
+	client := cloudsigma.NewBasicAuthClient(c.Username, c.Password, nil)
 	client.SetLocation(c.Location)
 	client.SetUserAgent(c.userAgent)
 

--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -20,6 +20,11 @@ func resourceCloudSigmaServer() *schema.Resource {
 		UpdateContext: resourceCloudSigmaServerUpdate,
 		DeleteContext: resourceCloudSigmaServerDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		SchemaVersion: 0,
 
 		Schema: map[string]*schema.Schema{

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cloudsigma/terraform-provider-cloudsigma
 
 require (
-	github.com/cloudsigma/cloudsigma-sdk-go v0.8.0
+	github.com/cloudsigma/cloudsigma-sdk-go v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudsigma/cloudsigma-sdk-go v0.8.0 h1:1Vhn+2bV4P4DXn3hilDQ4O0710koytRFjgAHhgfQyJ4=
-github.com/cloudsigma/cloudsigma-sdk-go v0.8.0/go.mod h1:/Ba78bdbHpRz4PcJLmt2TawfkHBVlAiq0/3AAfyPkyw=
+github.com/cloudsigma/cloudsigma-sdk-go v0.9.0 h1:FUdSjLtdIrGnk0AWJDEwug3xNa9vxAB1qvsyztE/3ns=
+github.com/cloudsigma/cloudsigma-sdk-go v0.9.0/go.mod h1:/Ba78bdbHpRz4PcJLmt2TawfkHBVlAiq0/3AAfyPkyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR updates CloudSigma SDK library to version v0.9.0.
This update allows to parametrize and customize `http.Client` passed to SDK.