### PR TITLE
build: package for darwin_arm64 (Apple Silicon M1) 

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -20,9 +20,6 @@ builds:
       - linux
       - openbsd
       - windows
-    ignore:
-      - goos: darwin
-        goarch: arm64
     mod_timestamp: '{{ .CommitTimestamp }}'
 changelog:
   skip: true


### PR DESCRIPTION
It is not possible to use `terraform-provider-cloudsigma` on recent M1 Macs because `darwin_arm64`:

```
> tf init
[...]
Initializing provider plugins...
│
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/cloudsigma/cloudsigma v1.4.2 does not have a package available for your current platform,
│ darwin_arm64.
```

It appears that `darwin_arm64`platform is specifically ignored in `.github/goreleaser.yml`, so fix that.