### PR TITLE
data-source/cloudsigma_drive: add new data source for drives

### DIFF
--- a/cloudsigma/data_source_cloudsigma_drive.go
+++ b/cloudsigma/data_source_cloudsigma_drive.go
@@ -1,0 +1,88 @@
+package cloudsigma
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cloudsigma/cloudsigma-sdk-go/cloudsigma"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceCloudSigmaDrive() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCloudSigmaDriveRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": dataSourceFiltersSchema(),
+
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceCloudSigmaDriveRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*cloudsigma.Client)
+
+	filters, filtersOk := d.GetOk("filter")
+	if !filtersOk {
+		return diag.Errorf("issue with filters: %v", filtersOk)
+	}
+
+	opts := &cloudsigma.DriveListOptions{
+		ListOptions: cloudsigma.ListOptions{Limit: 0},
+	}
+	libdrives, _, err := client.Drives.List(ctx, opts)
+	if err != nil {
+		return diag.Errorf("error getting drives: %v", err)
+	}
+
+	libdriveList := make([]cloudsigma.Drive, 0)
+
+	f := buildCloudSigmaDataSourceFilter(filters.(*schema.Set))
+	for _, libdrive := range libdrives {
+		sm, err := structToMap(libdrive)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if filterLoop(f, sm) {
+			libdriveList = append(libdriveList, libdrive)
+		}
+	}
+
+	if len(libdriveList) > 1 {
+		return diag.FromErr(errors.New("your search returned too many results. Please refine your search to be more specific"))
+	}
+	if len(libdriveList) < 1 {
+		return diag.FromErr(errors.New("no results were found"))
+	}
+
+	d.SetId(libdriveList[0].UUID)
+	_ = d.Set("name", libdriveList[0].Name)
+	_ = d.Set("size", libdriveList[0].Size)
+	_ = d.Set("status", libdriveList[0].Status)
+	_ = d.Set("storage_type", libdriveList[0].StorageType)
+	_ = d.Set("uuid", libdriveList[0].UUID)
+
+	return nil
+}

--- a/cloudsigma/provider.go
+++ b/cloudsigma/provider.go
@@ -34,6 +34,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"cloudsigma_ip":            dataSourceCloudSigmaIP(),
 			"cloudsigma_library_drive": dataSourceCloudSigmaLibraryDrive(),
+			"cloudsigma_drive":         dataSourceCloudSigmaDrive(),
 			"cloudsigma_license":       dataSourceCloudSigmaLicense(),
 			"cloudsigma_location":      dataSourceCloudSigmaLocation(),
 			"cloudsigma_profile":       dataSourceCloudSigmaProfile(),

--- a/docs/data-sources/drive.md
+++ b/docs/data-sources/drive.md
@@ -1,0 +1,35 @@
+--
+page_title: "CloudSigma: cloudsigma_drive"
+
+---
+
+# cloudsigma_drive
+
+Gets information about a drive.
+
+## Example Usage
+
+```hcl
+data "cloudsigma_drive" "debian" {
+  filter = {
+    name   = "name"
+    values = ["Debian 9.13 Server"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `filter` - (Optional) One or more name/value pairs to use as filters.
+
+## Attributes Reference
+
+In addition to all above arguments, the following attributes are exported:
+
+- `uuid`
+- `name`
+- `size`
+- `status`
+- `storage_type`


### PR DESCRIPTION
We need to extend the existing provider with a possibility to get a drive not only from the library but our custom one .
If you create a server with a drive based of the image from their library it will cause a server recreation when they update the image and hence the cloned drive will get a new base image id which forces a drive replacement
