### PR TITLE
feat: add base url configuration

### DIFF
--- a/cloudsigma/config.go
+++ b/cloudsigma/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Username string
 	Password string
 	Location string
+	BaseURL  string
 
 	context   context.Context
 	userAgent string
@@ -30,7 +31,7 @@ func (c *Config) Client() *cloudsigma.Client {
 		client = cloudsigma.NewBasicAuthClient(c.Username, c.Password, nil)
 		log.Printf("[INFO] CloudSigma Client configured for user: %s, location: %s", c.Username, c.Location)
 	}
-	client.SetLocation(c.Location)
+	client.SetAPIEndpoint(c.Location, c.BaseURL)
 	client.SetUserAgent(c.userAgent)
 
 	return client

--- a/cloudsigma/provider.go
+++ b/cloudsigma/provider.go
@@ -38,6 +38,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("CLOUDSIGMA_LOCATION", "zrh"),
 				Description: "The location endpoint for CloudSigma. Default is 'zrh'.",
 			},
+			"base_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDSIGMA_BASE_URL", "cloudsigma.com/api/2.0/"),
+				Description: "The base URL endpoint for CloudSigma. Default is 'cloudsigma.com/api/2.0/'.",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -30,8 +30,9 @@ provider "cloudsigma" {
 * The `username` field should be your user email.
 * The `password` field is your password.
 * The `location` field is optional (default value is `zrh`). If you want to try
-another location, check [avalaible locations](https://cloudsigma-docs.readthedocs.io/en/2.14.1/general.html#api-endpoint)
+another location, check [available locations](https://docs.cloudsigma.com/en/latest/general.html#api-endpoint)
 and use the location code as value.
+* The `base_url` field is optional (default value is `cloudsigma.com/api/2.0/`).
 
 ## Creating a Server
 Add the following to your config file:

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,4 +92,7 @@ The following arguments are supported:
   also be specified using an environment variable called `CLOUDSIGMA_PASSWORD`.
 * `location` - (Optional) This can be used to override the location for
   CloudSigma API requests (Defaults to the value of the `CLOUDSIGMA_LOCATION`
-  environment variable or `https://zrh.cloudsigma.com/api/2.0/` if unset).
+  environment variable or `zrh` if unset).
+* `base_url` - (Optional) This is the base URL for for CloudSigma API requests.
+  (Defaults to the value of the `CLOUDSIGMA_BASE_URL` environment variable or
+  `cloudsigma.com/api/2.0/` if unset). The value must end with a slash.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsigma/terraform-provider-cloudsigma
 go 1.17
 
 require (
-	github.com/cloudsigma/cloudsigma-sdk-go v0.10.0
+	github.com/cloudsigma/cloudsigma-sdk-go v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudsigma/cloudsigma-sdk-go v0.10.0 h1:TiTwEWQ8KkyZhRw30MUXf2nrqKHk34OFeUbh6R8oghU=
-github.com/cloudsigma/cloudsigma-sdk-go v0.10.0/go.mod h1:UKZyi/IK1T7cm2sBb9jF3gALFvtXKArrG7NgPYlSnoE=
+github.com/cloudsigma/cloudsigma-sdk-go v0.11.0 h1:YgjF4cMVnIa64jLY6t7aExWiqagDZoxx9Fmo5wMOwyY=
+github.com/cloudsigma/cloudsigma-sdk-go v0.11.0/go.mod h1:UKZyi/IK1T7cm2sBb9jF3gALFvtXKArrG7NgPYlSnoE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR adds a new configuration option `base_url`. It will allow to use the provider for on-prem API installations.

Example configuration:
```
provider "cloudsigma" {
  username = var.cloudsigma_username
  password = var.cloudsigma_password
  location = "loc12345"
  base_url = "custom-api-installation.com/api/2.0./"
}
```
The API endpoint for this configuration would be `https://loc12345.custom-api-installation.com/api/2.0/`