### PR TITLE
fix: propagate missing base_url option

### DIFF
--- a/cloudsigma/provider.go
+++ b/cloudsigma/provider.go
@@ -82,6 +82,7 @@ func providerConfigure(provider *schema.Provider) schema.ConfigureContextFunc {
 			Username: d.Get("username").(string),
 			Password: d.Get("password").(string),
 			Location: d.Get("location").(string),
+			BaseURL:  d.Get("base_url").(string),
 		}
 
 		config.loadAndValidate(ctx, provider.TerraformVersion)


### PR DESCRIPTION
This PR fixes the issue with default base_url and passing the option to the client.