### PR TITLE
fix(cloudsigma_server): change epc size type to int

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -51,7 +51,7 @@ func resourceCloudSigmaServer() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type: schema.TypeInt,
 				},
 			},
 

--- a/cloudsigma/structure_server.go
+++ b/cloudsigma/structure_server.go
@@ -7,7 +7,7 @@ func expandEnclavePageCaches(caches []interface{}) []cloudsigma.EnclavePageCache
 
 	for _, cache := range caches {
 		c := &cloudsigma.EnclavePageCache{
-			Size: cache.(string),
+			Size: cache.(int),
 		}
 		expandedCaches = append(expandedCaches, *c)
 	}

--- a/cloudsigma/structure_server_test.go
+++ b/cloudsigma/structure_server_test.go
@@ -16,15 +16,15 @@ func TestStructureServer_expandEnclavePageCaches(t *testing.T) {
 		{"Nil", nil, []cloudsigma.EnclavePageCache{}},
 		{
 			"SingleEPC",
-			[]interface{}{"100M"},
-			[]cloudsigma.EnclavePageCache{{Size: "100M"}},
+			[]interface{}{1024},
+			[]cloudsigma.EnclavePageCache{{Size: 1024}},
 		},
 		{
 			"MultipleEPCs",
-			[]interface{}{"100M", "200M"},
+			[]interface{}{1024, 2048},
 			[]cloudsigma.EnclavePageCache{
-				{Size: "100M"},
-				{Size: "200M"},
+				{Size: 1024},
+				{Size: 2048},
 			},
 		},
 	}
@@ -51,16 +51,16 @@ func TestStructureServer_flattenEnclavePageCaches(t *testing.T) {
 		{"Nil", nil, []interface{}{}},
 		{
 			"SingleEPC",
-			[]cloudsigma.EnclavePageCache{{Size: "100M"}},
-			[]interface{}{"100M"},
+			[]cloudsigma.EnclavePageCache{{Size: 1024}},
+			[]interface{}{1024},
 		},
 		{
 			"MultipleEPCs",
 			[]cloudsigma.EnclavePageCache{
-				{Size: "100M"},
-				{Size: "200M"},
+				{Size: 1024},
+				{Size: 2048},
 			},
-			[]interface{}{"100M", "200M"},
+			[]interface{}{1024, 2048},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudsigma/terraform-provider-cloudsigma
 go 1.17
 
 require (
-	github.com/cloudsigma/cloudsigma-sdk-go v0.12.0
+	github.com/cloudsigma/cloudsigma-sdk-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudsigma/cloudsigma-sdk-go v0.12.0 h1:jc4Nup5R9DK6dwd2Uk+vnvKMGsSz8YBTra+x0dJs+kI=
-github.com/cloudsigma/cloudsigma-sdk-go v0.12.0/go.mod h1:UKZyi/IK1T7cm2sBb9jF3gALFvtXKArrG7NgPYlSnoE=
+github.com/cloudsigma/cloudsigma-sdk-go v0.13.0 h1:XseZfWS0E6dblX43qyqAZswfWbOzzbvrHDR/F5UJIfg=
+github.com/cloudsigma/cloudsigma-sdk-go v0.13.0/go.mod h1:UKZyi/IK1T7cm2sBb9jF3gALFvtXKArrG7NgPYlSnoE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This PR fixes `enclave_page_caches` type to integer (instead of string).