### PR TITLE
Modified drive boot order setting when creating servers.

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -254,7 +254,7 @@ func resourceCloudSigmaServerCreate(ctx context.Context, d *schema.ResourceData,
 			drive := dr.(map[string]interface{})
 
 			serverDrives = append(serverDrives, cloudsigma.ServerDrive{
-				BootOrder:  len(serverDrives),
+				BootOrder:  1 + len(serverDrives),
 				DevChannel: fmt.Sprintf("0:%d", len(serverDrives)),
 				Device:     "virtio",
 				Drive:      &cloudsigma.Drive{UUID: drive["uuid"].(string)},
@@ -384,7 +384,7 @@ func resourceCloudSigmaServerUpdate(ctx context.Context, d *schema.ResourceData,
 			drive := dr.(map[string]interface{})
 
 			serverDrives = append(serverDrives, cloudsigma.ServerDrive{
-				BootOrder:  len(serverDrives),
+				BootOrder:  1 + len(serverDrives),
 				DevChannel: fmt.Sprintf("0:%d", len(serverDrives)),
 				Device:     "virtio",
 				Drive:      &cloudsigma.Drive{UUID: drive["uuid"].(string)},


### PR DESCRIPTION
Adds `1` to the `len(serverDrives)` value to ensure that
the boot order has a valid value.
Fixes cloudsigma/terraform-provider-cloudsigma#40