### PR TITLE
feat(resource/cloudsigma_drive): add optional storage_type field

### DIFF
--- a/cloudsigma/resource_cloudsigma_drive_test.go
+++ b/cloudsigma/resource_cloudsigma_drive_test.go
@@ -47,6 +47,10 @@ func TestAccCloudSigmaDrive_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("cloudsigma_drive.test", "tags.#", "0"),
 				),
 			},
+			{
+				Config:      testAccCloudSigmaDriveConfig_storageType(driveName),
+				ExpectError: regexp.MustCompile("drives `storage_type` cannot be changed after creation.*"),
+			},
 		},
 	})
 }
@@ -145,6 +149,17 @@ resource "cloudsigma_drive" "test" {
   media = "disk"
   name  = "%s"
   size  = 5 * 1024 * 1024 * 1024
+}
+`, driveName)
+}
+
+func testAccCloudSigmaDriveConfig_storageType(driveName string) string {
+	return fmt.Sprintf(`
+resource "cloudsigma_drive" "test" {
+  media = "disk"
+  name  = "%s"
+  size  = 5 * 1024 * 1024 * 1024
+  storage_type = "dssd"
 }
 `, driveName)
 }

--- a/docs/resources/drive.md
+++ b/docs/resources/drive.md
@@ -20,6 +20,17 @@ resource "cloudsigma_drive" "foobar" {
 }
 ```
 
+### With storage type
+
+```hcl
+resource "cloudsigma_drive" "foobar" {
+  media = "disk"
+  name  = "foobar"
+  size  = 5 * 1024 * 1024 * 1024 # 5GB
+  storage_type = "dssd"
+}
+```
+
 ### With additional tags
 ```hcl
 resource "cloudsigma_drive" "foobar" {
@@ -43,6 +54,7 @@ The following arguments are supported:
 * `media` - (Required) Media representation type. It can be `cdrom` or `disk`
 * `name` - (Required) Human readable name of the drive
 * `size` - (Required) Size of the drive in bytes
+* `storage_type` - (Optional) Drive storage type, cannot be changed after drive creation. Valid values are `dssd`, `zadara`, or `nvme`(default).
 * `tags` - (Optional) A list of the tags UUIDs to be applied to the drive.
 
 


### PR DESCRIPTION
Hi @pavel-github,

This implement the feature request #49.

The `storage_type` field is now available as **optional**, and validated against the current valid values ("dssd", "nvme", "zadara").

Also added a new check, in case someone want to change the `storage_type` after the drive creation, and terraform will return an error like this,

```console
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: drives `storage_type` cannot be changed after creation. new: dssd != current: nvme
│
│   with cloudsigma_drive.test_new_drive_storage_type,
│   on main.tf line 12, in resource "cloudsigma_drive" "test_new_drive_storage_type":
│   12: resource "cloudsigma_drive" "test_new_drive_storage_type" {
```
and tested via `testAccCloudSigmaDriveConfig_storageType` which increase coverage from 32,3% to 32.4%.

Thank you!

Mario