### PR TITLE
chore: Add gocritic linter and fix its findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - gocritic
     - gofmt
     - goimports
     - gosimple

--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -187,18 +187,19 @@ func resourceCloudSigmaServerCreate(ctx context.Context, d *schema.ResourceData,
 				return diag.Errorf("cannot assign both network type and vlan")
 			}
 
-			if networkType == "static" {
+			switch {
+			case networkType == "static":
 				conf := &cloudsigma.ServerIPConfiguration{
 					Type:      networkType,
 					IPAddress: &cloudsigma.IP{UUID: networkAddress},
 				}
 				createRequest.Servers[0].NICs[i].IP4Configuration = conf
-			} else if networkType == "dhcp" {
+			case networkType == "dhcp":
 				conf := &cloudsigma.ServerIPConfiguration{
 					Type: networkType,
 				}
 				createRequest.Servers[0].NICs[i].IP4Configuration = conf
-			} else if networkVlan != "" {
+			case networkVlan != "":
 				vlan := &cloudsigma.VLAN{
 					UUID: networkVlan,
 				}
@@ -422,20 +423,21 @@ func resourceCloudSigmaServerUpdate(ctx context.Context, d *schema.ResourceData,
 				return diag.Errorf("cannot assign both network type and vlan")
 			}
 
-			if networkType == "static" {
+			switch {
+			case networkType == "static":
 				serverNICs = append(serverNICs, cloudsigma.ServerNIC{
 					IP4Configuration: &cloudsigma.ServerIPConfiguration{
 						Type:      networkType,
 						IPAddress: &cloudsigma.IP{UUID: networkAddress},
 					},
 				})
-			} else if networkType == "dhcp" {
+			case networkType == "dhcp":
 				serverNICs = append(serverNICs, cloudsigma.ServerNIC{
 					IP4Configuration: &cloudsigma.ServerIPConfiguration{
 						Type: networkType,
 					},
 				})
-			} else if networkVlan != "" {
+			case networkVlan != "":
 				serverNICs = append(serverNICs, cloudsigma.ServerNIC{
 					VLAN: &cloudsigma.VLAN{
 						UUID: networkVlan,


### PR DESCRIPTION
Hi @pavel-github,

This is a trivial PR that fixes [go-critic](https://github.com/go-critic/go-critic) findings and enable it via `golangici-lint`.
See,
```
make lint
==> Linting code with 'golangci-lint'...
cloudsigma/resource_cloudsigma_server.go:190:4  gocritic  ifElseChain: rewrite if-else to switch statement
cloudsigma/resource_cloudsigma_server.go:425:4  gocritic  ifElseChain: rewrite if-else to switch statement
make: *** [lint] Error 1
```

Thank you,

Mario