### PR TITLE
chore: fix provider docs filter syntax

### DIFF
--- a/docs/data-sources/drive.md
+++ b/docs/data-sources/drive.md
@@ -11,7 +11,7 @@ Gets information about a drive.
 
 ```hcl
 data "cloudsigma_drive" "debian" {
-  filter = {
+  filter {
     name   = "name"
     values = ["Debian 9.13 Server"]
   }

--- a/docs/data-sources/ip.md
+++ b/docs/data-sources/ip.md
@@ -12,7 +12,7 @@ Gets information about an IP.
 
 ```hcl
 data "cloudsigma_ip" "my_ip" {
-  filter = {
+  filter {
     name   = "uuid"
     values = ["0.0.0.0"]
   }

--- a/docs/data-sources/library_drive.md
+++ b/docs/data-sources/library_drive.md
@@ -12,7 +12,7 @@ Gets information about a library drive.
 
 ```hcl
 data "cloudsigma_library_drive" "debian" {
-  filter = {
+  filter {
     name   = "name"
     values = ["Debian 9.13 Server"]
   }

--- a/docs/data-sources/location.md
+++ b/docs/data-sources/location.md
@@ -12,7 +12,7 @@ Gets information about a location.
 
 ```hcl
 data "cloudsigma_library_location" "frankfurt" {
-  filter = {
+  filter {
     name   = "id"
     values = ["FRA"]
   }

--- a/docs/data-sources/tag.md
+++ b/docs/data-sources/tag.md
@@ -12,7 +12,7 @@ Gets information about a Tag.
 
 ```hcl
 data "cloudsigma_tag" "my_production_tag" {
-  filter = {
+  filter {
     name   = "name"
     values = ["production"]
   }

--- a/docs/data-sources/vlan.md
+++ b/docs/data-sources/vlan.md
@@ -12,7 +12,7 @@ Gets information about a VLAN.
 
 ```hcl
 data "cloudsigma_vlan" "my_vlan" {
-  filter = {
+  filter {
     name   = "uuid"
     values = ["10619300-edda-42ba-91e0-7e3df0689d00"]
   }


### PR DESCRIPTION
Hi @pavel-github,

I've found that the provider documentation is wrong when defining data filters. This fix all occurrences.

See,
```console
│ Error: Unsupported argument
│
│   on data.tf line 2, in data "cloudsigma_library_drive" "cloudsigma_library_drives":
│    2:   filter = {
│
│ An argument named "filter" is not expected here. Did you mean to define a block of type "filter"?
```