### PR TITLE
feat(data-source/cloudsigma_vlan): filter VLANs by name

### DIFF
--- a/cloudsigma/data_source_cloudsigma_common_schema.go
+++ b/cloudsigma/data_source_cloudsigma_common_schema.go
@@ -2,6 +2,7 @@ package cloudsigma
 
 import (
 	"encoding/json"
+	"log"
 	"strconv"
 	"strings"
 
@@ -64,18 +65,32 @@ func structToMap(data interface{}) (map[string]interface{}, error) {
 }
 
 func filterLoop(f []filter, m map[string]interface{}) bool {
-	for _, filter := range f {
-		if !valuesLoop(filter.values, m[filter.name]) {
+	for idx := range f {
+		if !valuesLoop(f[idx].values, m[f[idx].name]) {
 			return false
 		}
 	}
 	return true
 }
 
+// valuesLoop search for a matching value for the defined "name".
+// Depending on the defined key, it could be a simple string or a JSON object
+// The function will search for any matching value.
 func valuesLoop(values []string, i interface{}) bool {
-	for _, v := range values {
-		if v == i {
-			return true
+	for idx := range values {
+		switch intCast := i.(type) {
+		case string:
+			if values[idx] == i {
+				return true
+			}
+		case map[string]interface{}:
+			for idx2 := range intCast {
+				if values[idx] == intCast[idx2] {
+					return true
+				}
+			}
+		default:
+			log.Printf("filter [valuesLoop] wrong type %T", intCast)
 		}
 	}
 	return false

--- a/cloudsigma/data_source_cloudsigma_vlan.go
+++ b/cloudsigma/data_source_cloudsigma_vlan.go
@@ -39,15 +39,15 @@ func dataSourceCloudSigmaVLANRead(ctx context.Context, d *schema.ResourceData, m
 
 	vlanList := make([]cloudsigma.VLAN, 0)
 
-	f := buildCloudSigmaDataSourceFilter(filters.(*schema.Set))
-	for _, vlan := range vlans {
-		sm, err := structToMap(vlan)
+	filter := buildCloudSigmaDataSourceFilter(filters.(*schema.Set))
+	for idx := range vlans {
+		sm, err := structToMap(vlans[idx])
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		if filterLoop(f, sm) {
-			vlanList = append(vlanList, vlan)
+		if filterLoop(filter, sm) {
+			vlanList = append(vlanList, vlans[idx])
 		}
 	}
 
@@ -59,6 +59,7 @@ func dataSourceCloudSigmaVLANRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(vlanList[0].UUID)
+	_ = d.Set("meta", vlanList[0].Meta)
 	_ = d.Set("resource_uri", vlanList[0].ResourceURI)
 
 	return nil

--- a/docs/data-sources/vlan.md
+++ b/docs/data-sources/vlan.md
@@ -19,6 +19,16 @@ data "cloudsigma_vlan" "my_vlan" {
 }
 ```
 
+## Example Usage, filter by VLAN name
+
+```hcl
+data "cloudsigma_vlan" "my_vlan" {
+  filter {
+    name   = "meta"
+    values = ["My VLAN Name"]
+  }
+}
+```
 
 ## Argument Reference
 
@@ -31,4 +41,6 @@ The following arguments are supported:
 
 In addition to all above arguments, the following attributes are exported:
 
-* `resource_uri`
+* `meta` - User defined meta information, for example the `name` field
+* `resource_uri` - VLAN API URI
+* `uuid` - VLAN UUID


### PR DESCRIPTION
Hi @pavel-github,

This PR resolves #14, allowing us to filter VLAN resources by name.

As the name field is inside `meta`, it just compares all the values inside the JSON object, and returns the matching object.

As far as I could test, this does not brake any other datasource and `make testacc` run successfully.

Thank you!