### PR TITLE
fix(resource/cloudsigma_server): handle empty network definition

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -183,6 +183,9 @@ func resourceCloudSigmaServerCreate(ctx context.Context, d *schema.ResourceData,
 		createRequest.Servers[0].NICs = make([]cloudsigma.ServerNIC, len(networks))
 
 		for i, n := range networks {
+			if n == nil {
+				return diag.Errorf("defined network argument is empty")
+			}
 			network := n.(map[string]interface{})
 			networkType := network["type"].(string)
 			networkAddress := network["ipv4_address"].(string)


### PR DESCRIPTION
Hi @pavel-github,

This handle issue #61, so that the provider does not crash on empty network definitions.

Thank you!