### PR TITLE
chore: sync golangci-lint configuration with scaffolding repo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,14 +1,22 @@
 linters:
   disable-all: true
   enable:
+    - durationcheck
     - errcheck
+    - exportloopref
+    #- forcetypeassert (disable for now)
+    - godot
     - gofmt
     - goimports
     - gosimple
     - govet
     - ineffassign
+    - makezero
     - misspell
+    - nilerr
+    - predeclared
     - staticcheck
+    - tenv
     - unconvert
     - unused
 

--- a/cloudsigma/version.go
+++ b/cloudsigma/version.go
@@ -1,4 +1,4 @@
 package cloudsigma
 
-// providerVersion is set during the release process to the release version of the binary
+// providerVersion is set during the release process to the release version of the binary.
 var providerVersion = "dev"


### PR DESCRIPTION
This PR syncs `.golangci.yaml` file with https://github.com/hashicorp/terraform-provider-scaffolding-framework and fixes open issues.