### PR TITLE
fix(resource/cloudsigma_server): handle empty network definition

### DIFF
--- a/cloudsigma/resource_cloudsigma_server.go
+++ b/cloudsigma/resource_cloudsigma_server.go
@@ -204,6 +204,9 @@ func resourceCloudSigmaServerCreate(ctx context.Context, d *schema.ResourceData,
 		createRequest.Servers[0].NICs = make([]cloudsigma.ServerNIC, len(networks))
 
 		for i, n := range networks {
+			if n == nil {
+				return diag.Errorf("defined network argument is empty")
+			}
 			network := n.(map[string]interface{})
 			networkType := network["type"].(string)
 			networkAddress := network["ipv4_address"].(string)


### PR DESCRIPTION
Cherry-pick from #62 and rebase against `main`.

Fixes #61 and #62.